### PR TITLE
Fix Firefox + Browserify ordering issue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@
 module.exports = function staticMethods (input) {
     if (!input) return [];
 
-    return Object.getOwnPropertyNames(input).filter(function (name) {
+    return Object.getOwnPropertyNames(input).filter(name => {
         return name !== 'name' &&
                name !== 'length' &&
                name !== 'prototype';

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,5 +10,11 @@
  * @return {Array} The static methods of the class.
  */
 module.exports = function staticMethods (input) {
-    return input ? Object.getOwnPropertyNames(input).slice(3) : [];
+    if (!input) return [];
+
+    return Object.getOwnPropertyNames(input).filter(function (name) {
+        return name !== 'name' &&
+               name !== 'length' &&
+               name !== 'prototype';
+    });
 };


### PR DESCRIPTION
Let's take this code as sample, then pipe through Browserify:

```js
var statics = require('static-methods');

class Sample {
  constructor(thing) {
    this.thing = thing;
  }

  static makeFun() {
    console.log('Do not make fun!');
  }
}

console.log(statics(Sample));
```

In V8 (Node.js, Chrome) the output is OK, but in Firefox it's not:

| | Chrome <sup>54</sup> | Firefox <sup>50</sup> |
| --- | --- | --- |
| **`getOwnPropertyNames`<br>(ordered)** | `length`<br>`name`<br>`prototype`<br>`makeFun` | `prototype`<br>`makeFun`<br>`length`<br>`name` |
| **Expected** | `makeFun` | `makeFun` |
| **Output** | `makeFun` | `name` |

Looking at the code there's a `.slice(3)`, and ordering problem has always been there between the two browsers.

This PR replaces `slice` by `filter` letting out `name`, `length` and `prototype`.